### PR TITLE
Replace Flake8, Black and isort pre-commit hooks with Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-# W504: Line break occurred after a binary operator
-extend-select = W504
-max-line-length = 99

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.11
 exclude: |
   (?x)(
       ^package-lock.json
@@ -12,19 +10,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-json
       - id: check-yaml
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.4
     hooks:
-      - id: flake8
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--filter-files"]
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.3.3
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,7 +197,6 @@ json5 = ">=0.9.11,<0.10.0"
 pathspec = ">=0.12.0,<0.13.0"
 PyYAML = ">=6.0,<7.0"
 regex = ">=2023.0.0,<2024.0.0"
-tomli = {version = ">=2.0.1,<3.0.0", markers = "python_version < \"3.11\""}
 tqdm = ">=4.62.2,<5.0.0"
 
 [[package]]
@@ -437,7 +436,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -645,7 +643,6 @@ sphinxcontrib-htmlhelp = ">=2.0.0"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = ">=1.1.9"
-tomli = {version = ">=2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
@@ -764,17 +761,6 @@ standalone = ["Sphinx (>=5)"]
 test = ["pytest"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "tqdm"
 version = "4.66.4"
 description = "Fast, Extensible Progress Meter"
@@ -824,5 +810,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "486e1cc998ee8ca3acbdc9137cc34cca59b767f4fbeaf761ed1a823c9b2d5a40"
+python-versions = "^3.11"
+content-hash = "63a4b3d665c8c73c666a03e20679d09bbe5a3e656317f0a50517565b3b875fd6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">=3.11"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
@@ -14,7 +17,7 @@ packages = [{include = "takao"}]
 include = ["takao/static/**/*"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 sphinx = ">=4"
 
 [tool.poetry.group.dev.dependencies]
@@ -30,3 +33,9 @@ profile="jinja"
 ignore="H020"
 indent=2
 extension="jinja2"
+
+[tool.ruff.lint]
+extend-select = ["B0", "I", "SIM", "UP"]
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma=false


### PR DESCRIPTION
This replaces the Flake8, Black and isort pre-commit hooks with Ruff.