### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       actions:
         patterns:
@@ -13,8 +15,10 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     versioning-strategy: increase
+    cooldown:
+      default-days: 3
     groups:
       babel:
         patterns:
@@ -26,4 +30,6 @@ updates:
   - package-ecosystem: uv
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
This updates the Dependabot configuration to add a 3-day cooldown on updates and to change the update interval from daily to weekly.